### PR TITLE
Suicide by tank now gibs

### DIFF
--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -117,17 +117,18 @@
 	user.visible_message("<span class='suicide'>[user] is putting [src]'s valve to [user.p_their()] lips! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(loc, 'sound/effects/spray.ogg', 10, 1, -3)
 	if (H && !qdeleted(H))
-		for(var/obj/item/W in H)
-			H.dropItemToGround(W)
-			if(prob(50))
-				step(W, pick(alldirs))
-		H.hair_style = "Bald"
-		H.update_hair()
-		H.bleed_rate = 5
-		new /obj/effect/gibspawner/generic(H.loc, H.viruses, H.dna)
-		H.adjustBruteLoss(1000) //to make the body super-bloody
-
-	return (BRUTELOSS)
+		spawn(0)
+			var/list/items = H.get_equipped_items()
+			for(var/obj/item/i in items)
+				H.dropItemToGround(i)
+			H.drop_all_held_items()
+			for(var/obj/item/i in get_turf(H))
+				i.add_blood(H)
+			if(H.loc)
+				src.loc = null
+				src.loc = H.loc
+			H.gib()
+	return BRUTELOSS
 
 /obj/item/weapon/tank/attackby(obj/item/weapon/W, mob/user, params)
 	add_fingerprint(user)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -117,7 +117,7 @@
 	user.visible_message("<span class='suicide'>[user] is putting [src]'s valve to [user.p_their()] lips! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(loc, 'sound/effects/spray.ogg', 10, 1, -3)
 	if (H && !qdeleted(H))
-		spawn(0)
+		spawn(3)
 			var/list/items = H.get_equipped_items()
 			for(var/obj/item/i in items)
 				H.dropItemToGround(i)


### PR DESCRIPTION
:cl: Kitty Kathy
tweak: oxygen tank suicide now gibs you and and drops the stuff you are wearing.
/:cl:

Fixes suicide by oxygen tanks now they actually gib you like pre rebase. You also drop all your stuff you are wearing so almost nothing is lost by getting oxygen tank gibed of value anyway.

Before:
![before](https://cloud.githubusercontent.com/assets/24830804/22686644/de6a6d0e-ecf2-11e6-8a97-8a2a98bfd370.png)

After:
![after](https://cloud.githubusercontent.com/assets/24830804/22686649/e9f81770-ecf2-11e6-8731-9e3388b2a0d5.png)

*edited to add before and after pictures