### PR TITLE
Ash Walker improvements

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -52,10 +52,11 @@
 /obj/item/weapon/pickaxe,
 /obj/item/weapon/pickaxe,
 /obj/structure/closet/crate/internals,
-/obj/item/weapon/pickaxe,
-/obj/item/weapon/pickaxe,
-/obj/item/weapon/pickaxe,
 /obj/item/weapon/storage/box/rxglasses,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -79,6 +80,9 @@
 "m" = (
 /obj/structure/closet/crate/medical,
 /obj/item/device/malf_upgrade,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/regular,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -90,6 +94,7 @@
 /obj/item/seeds/glowshroom,
 /obj/item/seeds/glowshroom,
 /obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/storage/backpack/botany,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -153,6 +158,7 @@
 /obj/structure/closet/crate/medical,
 /obj/item/weapon/storage/firstaid/regular,
 /obj/item/weapon/reagent_containers/blood/random,
+/obj/item/clothing/glasses/hud/health,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -169,7 +175,9 @@
 	icon_state = "minibar_left";
 	name = "skeletal minibar"
 	},
-/obj/item/stack/sheet/cloth/ten,
+/obj/item/stack/sheet/cloth{
+	amount = 20
+	},
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -181,6 +189,9 @@
 	name = "skeletal minibar"
 	},
 /obj/item/clothing/head/helmet/roman/legionaire,
+/obj/item/stack/sheet/cloth{
+	amount = 20
+	},
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -188,6 +199,9 @@
 "z" = (
 /obj/item/weapon/shovel,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/weapon/pickaxe/drill,
+/obj/item/weapon/pickaxe/drill,
+/obj/item/weapon/pickaxe/drill,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -202,6 +216,9 @@
 /area/ruin/unpowered)
 "B" = (
 /obj/structure/table_frame,
+/obj/item/stack/sheet/cloth{
+	amount = 20
+	},
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -266,6 +283,9 @@
 "L" = (
 /obj/item/weapon/twohanded/spear,
 /obj/structure/table,
+/obj/item/stack/sheet/cloth{
+	amount = 20
+	},
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -282,7 +302,22 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "O" = (
-/obj/item/weapon/reagent_containers/glass/bowl,
+/obj/item/weapon/reagent_containers/glass/bucket{
+	desc = "For milking the gibbucks.";
+	name = "milk bucket"
+	},
+/obj/item/weapon/reagent_containers/glass/bucket{
+	desc = "For milking the gibbucks.";
+	name = "milk bucket"
+	},
+/obj/item/weapon/reagent_containers/glass/bucket{
+	desc = "For milking the gibbucks.";
+	name = "milk bucket"
+	},
+/obj/item/weapon/reagent_containers/glass/bucket{
+	desc = "For milking the gibbucks.";
+	name = "milk bucket"
+	},
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -305,6 +340,35 @@
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/unpowered)
+"S" = (
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 8;
+	output_dir = 4;
+	req_access = null
+	},
+/turf/open/floor/engine/cult{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/unpowered)
+"T" = (
+/obj/item/weapon/twohanded/spear,
+/obj/structure/rack,
+/obj/item/device/mining_scanner,
+/obj/item/device/mining_scanner,
+/obj/item/device/mining_scanner,
+/obj/item/device/mining_scanner,
+/turf/open/floor/engine/cult{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/unpowered)
+"U" = (
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"V" = (
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 
 (1,1,1) = {"
 a
@@ -363,7 +427,7 @@ r
 r
 r
 b
-b
+V
 b
 "}
 (4,1,1) = {"
@@ -397,7 +461,7 @@ j
 m
 r
 v
-P
+f
 R
 f
 L
@@ -416,11 +480,11 @@ i
 f
 n
 r
-w
+P
 f
 D
 H
-H
+T
 r
 b
 b
@@ -471,7 +535,7 @@ a
 a
 c
 g
-f
+g
 O
 f
 p
@@ -481,7 +545,7 @@ Q
 f
 r
 b
-b
+U
 K
 K
 K
@@ -498,7 +562,7 @@ q
 r
 y
 f
-f
+S
 r
 K
 b

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -58,7 +58,6 @@
 	description = "A race of unbreathing lizards live here, that run faster than a human can, worship a broken dead city, and are capable of reproducing by something involving tentacles? \
 	Probably best to stay clear."
 	suffix = "lavaland_surface_ash_walker1.dmm"
-	cost = 20
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/syndicate_base

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -36,7 +36,7 @@
 	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
 	icon_state = "large_egg"
 	mob_species = /datum/species/lizard/ashwalker
-	helmet = /obj/item/clothing/head/helmet/gladiator
+	helmet = /obj/item/clothing/head/helmet/gladiator/ash_walker
 	uniform = /obj/item/clothing/under/gladiator/ash_walker
 	roundstart = FALSE
 	death = FALSE

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -156,6 +156,10 @@
 	flags_cover = HEADCOVERSEYES
 	dog_fashion = null
 
+/obj/item/clothing/head/helmet/gladiator/ash_walker
+	desc = "This gladiator helmet appears to be covered in ash and fairly dated."
+	armor = list(melee = 35, bullet = 0, laser = 25, energy = 10, bomb = 10, bio = 0, rad = 0, fire = 50, acid = 50)
+
 /obj/item/clothing/head/helmet/redtaghelm
 	name = "red laser tag helmet"
 	desc = "They have chosen their own end."

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -426,7 +426,9 @@
 
 /obj/item/clothing/under/gladiator/ash_walker
 	desc = "This gladiator uniform appears to be covered in ash and fairly dated."
+	armor = list(melee = 35, bullet = 0, laser = 15, energy = 10, bomb = 10, bio = 0, rad = 0, fire = 50, acid = 20)
 	has_sensor = 0
+
 
 /obj/item/clothing/under/sundress
 	name = "sundress"


### PR DESCRIPTION
:cl: cacogen
add: Gave Ash Walker nest more equipment
add: Gave Ash Walker nest an ore redemption machine
tweak: Improved Ash Walker armour
tweak: Added an extra egg and two extra bodies to the nest
tweak: Ash Walker nest now spawns more often
/:cl:

![](https://puu.sh/tX8nI/8fe91cc9e7.png)

**Details:**
_Replaced three of the picks with drills:_ Sometimes the ruins spawn in the middle of dense rock with no tunnels nearby or all tunnels lead to dead ends and mining with the default pick takes forever (the drills are only marginally faster)
_Added mesons:_ So Ash Walkers can actually see the layout of the tunnels around them and more easily find their way on the asteroid
_Added ore redemption machine:_ So they can build things with the stuff they mine, like a settlement
_Added manual scanners:_ So Ash Walkers can see what they're mining. Note that regular miners get automatic scanners.
_medHUDs:_ Monitor yours and enemies' health due to the extreme damage outputs of enemies on Lavaland and their high health (though the mesons make a better choice of eyewear)
_Added two extra basic medkits:_ In testing gibbuck milk wasn't very good (I should buff it actually instead) so without a legion soul you're fucked if you're low on health
_Added extra cloth stacks:_ So more than one Ash Walker can have a backpack
_Milk buckets instead of a bowl:_ The bowl wasn't very intuitive and there was only one, so only one ash walker could heal using the gibbuck milk

**Try playtesting this before commenting on the balance.**

I wanted to make it more likely I'd get to play Ash Walker by increasing the likelihood of the nest ruin spawning, and adding more eggs and more bodies to the Ash Walker nest to start out with.

I also wanted to improve the experience of playing Ash Walker by making it less difficult and less tedious by giving the Ash Walkers better equipment. I also gave them an ore redemption machine so they can build things with the materials they've mined.

It's still very easy to get killed due to the large amounts of powerful enemies on Lavaland, but hopefully this will make those deaths slightly rarer and less punishing to the Ash Walkers as a whole.

**todo:**

- [ ] make corpses into miners as a more organic way of giving ash walkers mining supplies and as a way to give them headsets to coordinate
- [ ]  look at buffing gibbuck milk instead of adding more medkits
- [ ] look at making the nest into an old mining outpost to justify the presence of the ore redemption machine
- [ ] ~~add some dirt piles to grow shit~~ (no need - these can be built with ash gathered with the shovel)