### PR TITLE
Adds estimations of an object's force and throwforce to examine messages

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -159,12 +159,40 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 /obj/item/examine(mob/user) //This might be spammy. Remove?
 	..()
 	var/pronoun
+	var/property_msg
 	if(src.gender == PLURAL)
 		pronoun = "They are"
 	else
 		pronoun = "It is"
 	var/size = weightclass2text(src.w_class)
-	user << "[pronoun] a [size] item." //e.g. They are a small item. or It is a bulky item.
+
+	property_msg += "[pronoun] a [size] item. " //e.g. They are a small item. or It is a bulky item.
+
+	switch(force)
+		if(1 to 5)
+			property_msg += "It doesn't look like a very good melee weapon. " //unless it's an unwielded fire axe or an off energy sword
+		if(5 to 10)
+			property_msg += "It looks like an okay melee weapon. "
+		if(10 to 15)
+			property_msg += "It looks like a strong melee weapon. "
+		if(15 to 20)
+			property_msg += "It looks like a dangerous melee weapon. "
+		if(20 to INFINITY)
+			property_msg += "It looks like an extremely dangerous melee weapon. "
+
+	switch(throwforce)
+		if(1 to 5)
+			property_msg += "It doesn't look like a very good throwing weapon. " //unless it's a turned off energy sword
+		if(5 to 10)
+			property_msg += "It looks like an okay throwing weapon. "
+		if(10 to 15)
+			property_msg += "It looks like a strong throwing weapon. "
+		if(15 to 20)
+			property_msg += "It looks like a dangerous throwing weapon. "
+		if(20 to INFINITY)
+			property_msg += "It looks like an extremely dangerous throwing weapon. "
+
+	user << "[property_msg]"
 
 	if(user.research_scanner) //Mob has a research scanner active.
 		var/msg = "*--------* <BR>"
@@ -186,7 +214,6 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 			msg += "<span class='danger'>No extractable materials detected.</span><BR>"
 		msg += "*--------*"
 		user << msg
-
 
 /obj/item/attack_self(mob/user)
 	interact(user)


### PR DESCRIPTION
:cl: cacogen
add: Added descriptions of an object's force and throwforce to examine messages
/:cl:

![](https://puu.sh/tUmrf/7c63eb7efd.png)

[]: # (Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)
No longer have to read the code or use a health analyser to know if something is a good weapon or not.

There's a problem in that certain weapons' forces change based on their state (turned off esword, unwielded fireaxe) or their value as weapons aren't based on their force (fork and screwdriver for eyestabs and stuns) and this code isn't robust enough to take that into account when describing them. Personally I think this is worth that, but if anyone has any suggestions on improving the code to take those things into account (and just in general) I'd be open to them. 