### PR TITLE
 Why is this runtiming?

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -15,7 +15,10 @@
 /datum/reagent/consumable/on_mob_life(mob/living/M)
 	current_cycle++
 	M.nutrition += nutriment_factor
-	holder.remove_reagent(src.id, metabolization_rate)
+	if (holder)
+		holder.remove_reagent(src.id, metabolization_rate)
+	else
+		warning("The holder was null in on_mob_life ???")
 
 /datum/reagent/consumable/nutriment
 	name = "Nutriment"


### PR DESCRIPTION
```runtime error:
[16:41:16]Cannot execute null.remove reagent().
[16:41:16]proc name: on mob life (/datum/reagent/consumable/on_mob_life)
[16:41:16]  source file: food_reagents.dm,18
[16:41:16]  usr: null
[16:41:16]  src: Banana Juice (/datum/reagent/consumable/banana)
[16:41:16]  call stack:
[16:41:16]Banana Juice (/datum/reagent/consumable/banana): on mob life(Krabby Patty Supreme (/mob/living/carbon/human))
[16:41:16]Banana Juice (/datum/reagent/consumable/banana): on mob life(Krabby Patty Supreme (/mob/living/carbon/human))
[16:41:16]/datum/reagents (/datum/reagents): metabolize(Krabby Patty Supreme (/mob/living/carbon/human), 1)
[16:41:16]Krabby Patty Supreme (/mob/living/carbon/human): handle chemicals in body()
[16:41:16]Krabby Patty Supreme (/mob/living/carbon/human): Life(2)
[16:41:16]Krabby Patty Supreme (/mob/living/carbon/human): Life(2)
[16:41:16]Krabby Patty Supreme (/mob/living/carbon/human): Life(2)
[16:41:16]Mobs (/datum/subsystem/mobs): fire(0)
[16:41:16]Mobs (/datum/subsystem/mobs): ignite(0)
[16:41:16]Master (/datum/controller/master): RunQueue()
[16:41:16]Master (/datum/controller/master): Loop()
[16:41:16]Master (/datum/controller/master): StartProcessing(0)```

Fixes this?