### PR TITLE
Fixes putting food and pills in butt

### DIFF
--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -84,6 +84,8 @@
 			if(H.w_uniform)
 				user << "<span class='danger'>Remove the jumpsuit first!</span>"
 				return
+		if(istype(W, /obj/item/weapon/reagent_containers/pill) || istype(W, /obj/item/weapon/reagent_containers/food))
+			START_PROCESSING(SSobj, W)
 	. = ..()
 
 /obj/item/weapon/storage/internal/pocket/butt/Adjacent(A)


### PR DESCRIPTION
:cl: Tortellini Tony
fix: Food and pills will be absorbed when placed in butt storage
/:cl:

Doesn't appear to cause a runtime. Before they would only START_PROCESSING when you used the grab intent and stuff.