### PR TITLE
fixes #165

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -22,8 +22,8 @@
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
 #define MAX_MESSAGE_LEN			1024
-#define MAX_MESSAGE_LEN_IC		300 //for messages users write in character (e.g. say, prayers)
-#define MAX_MESSAGE_LEN_OOC		300 //for messages users write out of character (e.g. ooc, adminhelp, dsay, asay)
+#define MAX_MESSAGE_LEN_IC		300 //for messages users send in character (e.g. say, emotes, prayers, pda, announcements, AI laws)
+#define MAX_MESSAGE_LEN_OOC		300 //for messages users send out of character (e.g. ooc, adminhelp, dsay)
 #define MAX_NAME_LEN			70
 #define MAX_BROADCAST_LEN		300
 #define MAX_CHARTER_LEN			80

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -22,8 +22,10 @@
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
 #define MAX_MESSAGE_LEN			1024
-#define MAX_NAME_LEN			42
-#define MAX_BROADCAST_LEN		512
+#define MAX_MESSAGE_LEN_IC		300 //for messages users write in character (e.g. say, prayers)
+#define MAX_MESSAGE_LEN_OOC		300 //for messages users write out of character (e.g. ooc, adminhelp, dsay, asay)
+#define MAX_NAME_LEN			70
+#define MAX_BROADCAST_LEN		300
 #define MAX_CHARTER_LEN			80
 
 //MINOR TWEAKS/MISC

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -132,7 +132,7 @@
 /mob/camera/blob/proc/blob_talk(message)
 	log_say("[key_name(src)] : [message]")
 
-	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
+	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN_IC))
 
 	if (!message)
 		return

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -263,7 +263,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 	if(reject_bad_text(href_list["write"]))
 		dpt = ckey(href_list["write"]) //write contains the string of the receiving department's name
 
-		var/new_message = copytext(reject_bad_text(input(usr, "Write your message:", "Awaiting Input", "")),1,MAX_MESSAGE_LEN)
+		var/new_message = copytext(reject_bad_text(input(usr, "Write your message:", "Awaiting Input", "")),1,MAX_MESSAGE_LEN_IC)
 		if(new_message)
 			message = new_message
 			screen = 9
@@ -279,7 +279,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 			priority = -1
 
 	if(href_list["writeAnnouncement"])
-		var/new_message = copytext(reject_bad_text(input(usr, "Write your message:", "Awaiting Input", "")),1,MAX_MESSAGE_LEN)
+		var/new_message = copytext(reject_bad_text(input(usr, "Write your message:", "Awaiting Input", "")),1,MAX_MESSAGE_LEN_IC)
 		if(new_message)
 			message = new_message
 			if (text2num(href_list["priority"]) < 2)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -584,7 +584,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		update_icon()
 
 /obj/item/device/pda/proc/msg_input(mob/living/U = usr)
-	var/t = stripped_input(U, "Please enter message", name, null, MAX_MESSAGE_LEN)
+	var/t = stripped_input(U, "Please enter message", name, null, MAX_MESSAGE_LEN_IC)
 	if (!t || toff)
 		return
 	if (!in_range(src, U) && loc != U)

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -244,7 +244,7 @@ AI MODULES
 			return
 		newpos = 15
 	lawpos = min(newpos, 50)
-	var/targName = stripped_input(user, "Please enter a new law for the AI.", "Freeform Law Entry", laws[1], MAX_MESSAGE_LEN)
+	var/targName = stripped_input(user, "Please enter a new law for the AI.", "Freeform Law Entry", laws[1], MAX_MESSAGE_LEN_IC)
 	if(!targName)
 		return
 	laws[1] = targName
@@ -320,7 +320,7 @@ AI MODULES
 	var/subject = "human being"
 
 /obj/item/weapon/aiModule/core/full/asimov/attack_self(var/mob/user as mob)
-	var/targName = stripped_input(user, "Please enter a new subject that asimov is concerned with.", "Asimov to whom?", subject, MAX_MESSAGE_LEN)
+	var/targName = stripped_input(user, "Please enter a new subject that asimov is concerned with.", "Asimov to whom?", subject, MAX_NAME_LEN)
 	if(!targName)
 		return
 	subject = targName
@@ -447,7 +447,7 @@ AI MODULES
 	laws = list("")
 
 /obj/item/weapon/aiModule/syndicate/attack_self(mob/user)
-	var/targName = stripped_input(user, "Please enter a new law for the AI.", "Freeform Law Entry", laws[1],MAX_MESSAGE_LEN)
+	var/targName = stripped_input(user, "Please enter a new law for the AI.", "Freeform Law Entry", laws[1],MAX_MESSAGE_LEN_IC)
 	if(!targName)
 		return
 	laws[1] = targName

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -163,7 +163,7 @@ update_label("John Doe", "Clowny")
 					return
 				registered_name = t
 
-				var u = copytext(sanitize(input(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels other than Maintenance.", "Agent card job assignment", "Assistant")as text | null),1,MAX_MESSAGE_LEN)
+				var u = copytext(sanitize(input(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels other than Maintenance.", "Agent card job assignment", "Assistant")as text | null),1,MAX_NAME_LEN)
 				if(!u)
 					registered_name = ""
 					return

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -94,7 +94,7 @@
 	//clean the input msg
 	if(!msg)
 		return
-	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
+	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN_OOC))
 	if(!msg)	return
 	var/original_msg = msg
 
@@ -157,7 +157,7 @@
 			final = "[msg] - All admins AFK ([adm["afk"]]/[adm["total"]]), stealthminned ([adm["stealth"]]/[adm["total"]]), or lack[rights2text(requiredflags, " ")] ([adm["noflags"]]/[adm["total"]])"
 		send2irc(source,final)
 		send2otherserver(source,final)
-		
+
 
 
 /proc/send2irc(msg,msg2)

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -14,7 +14,7 @@
 	if (src.handle_spam_prevention(msg,MUTE_DEADCHAT))
 		return
 
-	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
+	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN_OOC)
 	log_dsay("[key_name(src)] : [msg]")
 
 	if (!msg)

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -6,7 +6,7 @@
 		usr << "<span class='danger'>Speech is currently admin-disabled.</span>"
 		return
 
-	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
+	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN_IC)
 	if(!msg)
 		return
 	log_prayer("[src.key]/([src.name]): [msg]")
@@ -50,7 +50,7 @@
 	//log_admin("HELP: [key_name(src)]: [msg]")
 
 /proc/Centcomm_announce(text , mob/Sender)
-	var/msg = copytext(sanitize(text), 1, MAX_MESSAGE_LEN)
+	var/msg = copytext(sanitize(text), 1, MAX_MESSAGE_LEN_IC)
 	msg = "<span class='adminnotice'>\
 		<b><font color=orange>CENTCOM:</font>\
 		[ADMIN_FULLMONTY(Sender)] [ADMIN_BSA(Sender)] \
@@ -61,7 +61,7 @@
 		C.overrideCooldown()
 
 /proc/Syndicate_announce(text , mob/Sender)
-	var/msg = copytext(sanitize(text), 1, MAX_MESSAGE_LEN)
+	var/msg = copytext(sanitize(text), 1, MAX_MESSAGE_LEN_IC)
 	msg = "<span class='adminnotice'><b>\
 		<font color=crimson>SYNDICATE:</font>\
 		[ADMIN_FULLMONTY(Sender)] [ADMIN_BSA(Sender)] \
@@ -72,7 +72,7 @@
 		C.overrideCooldown()
 
 /proc/Nuke_request(text , mob/Sender)
-	var/msg = copytext(sanitize(text), 1, MAX_MESSAGE_LEN)
+	var/msg = copytext(sanitize(text), 1, MAX_MESSAGE_LEN_IC)
 	msg = "<span class='adminnotice'>\
 		<b><font color=orange>NUKE CODE REQUEST:</font>\
 		[ADMIN_FULLMONTY(Sender)] [ADMIN_BSA(Sender)] \

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -13,7 +13,7 @@
 		src << "Guests may not use OOC."
 		return
 
-	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
+	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN_OOC)
 	var/raw_msg = msg
 
 	if(!msg)

--- a/code/modules/hippie/mentor/verbs/mentorhelp.dm
+++ b/code/modules/hippie/mentor/verbs/mentorhelp.dm
@@ -9,7 +9,7 @@
 
 	//clean the input msg
 	if(!msg)	return
-	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
+	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN_OOC))
 	if(!msg)	return
 	if(!mob)	return						//this doesn't happen
 

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -1,5 +1,5 @@
 /mob/dead/observer/say(message)
-	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
+	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN_OOC))
 
 	if (!message)
 		return

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -460,7 +460,7 @@
 		user << "You cannot send IC messages (muted)."
 		return FALSE
 	else if(!params)
-		var/custom_emote = copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN)
+		var/custom_emote = copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN_IC)
 		if(custom_emote && !check_invalid(user, custom_emote))
 			var/type = input("Is this a visible or hearable emote?") as null|anything in list("Visible", "Hearable")
 			switch(type)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -62,7 +62,7 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 
 /mob/living/say(message, bubble_type,var/list/spans = list(), sanitize = TRUE)
 	if(sanitize)
-		message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
+		message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN_IC))
 	if(!message || message == "")
 		return
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -59,8 +59,7 @@ var/next_mob_id = 0
 	if(!client)
 		return
 
-	msg = copytext(msg, 1, MAX_MESSAGE_LEN)
-
+	msg = copytext(msg, 1, MAX_MESSAGE_LEN) //it seems using this again on the same message with the same value halves its length (why, though?)
 	if(type)
 		if(type & 1 && eye_blind )//Vision related
 			if(!alt_msg)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -23,7 +23,7 @@
 		usr << "<span class='danger'>Speech is currently admin-disabled.</span>"
 		return
 
-	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
+	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN_IC))
 
 	usr.emote("me",1,message)
 


### PR DESCRIPTION
fixes #174 

:cl: cacogen
tweak: Lowers max length of certain messages (e.g. OOC, say) from 1024 chars to 300 to cut back on spam
tweak: Increases max name length from 42 characters to 70
/:cl:

also increases max_name_len from 42 to 70 because i've run into problems with things that use it being too long a bunch of times