### PR TITLE
Replaces the issue button with an issue reporter

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -53,6 +53,19 @@
 	set hidden = 1
 
 	var/compileinfo = ""
+	var/message = "This will open the issue reporter. Are you sure?"
+	var/first = TRUE
+	
+	if(config.githuburl)
+		for(var/line in revdata.testmerge)
+			if(line)
+				if(first)
+					first = FALSE
+					message += ". The following experimental changes are active and are probably the cause of any new or sudden issues you may experience. If possible, please try to find a specific thread for your issue instead of posting to the general issue tracker:"
+			message += " <a href='[config.githuburl]/pull/[line]'>#[line]</a>"
+
+	if(tgalert(src, message, "Report Issue","Yes","No")=="No")
+		return
 
 	if(revdata.parentcommit)
 		compileinfo = url_encode("Server revision [revdata.parentcommit] compiled on: [revdata.date]")

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -51,20 +51,17 @@
 	set name = "report-issue"
 	set desc = "Report an issue"
 	set hidden = 1
-	if(config.githuburl)
-		var/message = "This will open the Github issue reporter in your browser. Are you sure?"
-		var/first = TRUE
-		for(var/line in revdata.testmerge)
-			if(line)
-				if(first)
-					first = FALSE
-					message += ". The following experimental changes are active and are probably the cause of any new or sudden issues you may experience. If possible, please try to find a specific thread for your issue instead of posting to the general issue tracker:"
-				message += " <a href='[config.githuburl]/pull/[line]'>#[line]</a>"
-		if(tgalert(src, message, "Report Issue","Yes","No")=="No")
-			return
-		src << link("[config.githuburl]/issues/new")
+
+	var/compileinfo = ""
+
+	if(revdata.parentcommit)
+		compileinfo = url_encode("Server revision [revdata.parentcommit] compiled on: [revdata.date]")
 	else
-		src << "<span class='danger'>The Github URL is not set in the server configuration.</span>"
+		compileinfo = url_encode("Unknown server revision")
+
+	var/dat = {"	<title>Hippie Station 13 Github Ingame Reporting</title>
+					<iframe src='https://tools.hippiestation.com/githubreport/?ckey=[ckey(key)]&sinfo=[compileinfo]' style='border:none' width='850' height='660' scroll=no></iframe>"}
+	src << browse(dat, "window=github;size=900x700")
 	return
 
 /client/verb/hotkeys_help()


### PR DESCRIPTION
:cl: JamieH
add: You no longer need a GitHub account to make issues, you can do it all in-game using the "Report Issue" button in the top right.
/:cl:
