### PR TITLE
Fixed not being able to remove embedded objects without surgery

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -213,6 +213,10 @@
 	if(legcuffed)
 		dat += "<tr><td><A href='?src=\ref[src];item=[slot_legcuffed]'>Legcuffed</A></td></tr>"
 
+	for(var/obj/item/bodypart/L in bodyparts)
+		for(var/obj/item/I in L.embedded_objects)
+			dat += "<tr><td><a href='byond://?src=\ref[src];embedded_object=\ref[I];embedded_limb=\ref[L]'>Embedded in [L]: [I]</a><br></td></tr>"
+
 	dat += {"</table>
 	<A href='?src=\ref[user];mach_close=mob\ref[src]'>Close</A>
 	"}
@@ -240,7 +244,8 @@
 			if(!I || !L || I.loc != src || !(I in L.embedded_objects)) //no item, no limb, or item is not in limb or in the person anymore
 				return
 			var/time_taken = I.embedded_unsafe_removal_time*I.w_class
-			usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from their [L.name].</span>","<span class='notice'>You attempt to remove [I] from your [L.name]... (It will take [time_taken/10] seconds.)</span>")
+			usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [usr == src ? "their" : name + "'s"] [L.name].</span>",\
+				                "<span class='notice'>You attempt to remove [I] from [usr == src ? "your" : name + "'s"] [L.name]... (It will take [time_taken/10] seconds.)</span>")
 			if(do_after(usr, time_taken, needhand = 1, target = src))
 				if(!I || !L || I.loc != src || !(I in L.embedded_objects))
 					return
@@ -248,8 +253,10 @@
 				L.receive_damage(I.embedded_unsafe_removal_pain_multiplier*I.w_class)//It hurts to rip it out, get surgery you dingus.
 				I.forceMove(get_turf(src))
 				usr.put_in_hands(I)
-				usr.emote("scream")
-				usr.visible_message("[usr] successfully rips [I] out of their [L.name]!","<span class='notice'>You successfully remove [I] from your [L.name].</span>")
+				emote("scream")
+
+				visible_message("[usr] successfully rips [I] out of [usr == src ? "their" : name + "'s"] [L.name]!",\
+					            "<span class='notice'>You successfully remove [I] from [usr == src ? "your" : name + "'s"] [L.name].</span>")
 				if(!has_embedded_objects())
 					clear_alert("embeddedobject")
 			return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -213,10 +213,13 @@
 	if(legcuffed)
 		dat += "<tr><td><A href='?src=\ref[src];item=[slot_legcuffed]'>Legcuffed</A></td></tr>"
 
-	for(var/obj/item/bodypart/L in bodyparts)
-		for(var/obj/item/I in L.embedded_objects)
-			dat += "<tr><td><a href='byond://?src=\ref[src];embedded_object=\ref[I];embedded_limb=\ref[L]'>Embedded in [L]: [I]</a><br></td></tr>"
+	for(var/I in bodyparts)
+		if(istype(I, /obj/item/bodypart))
+			var/obj/item/bodypart/L = I
 
+			for(var/obj/item/J in L.embedded_objects)
+				dat += "<tr><td><a href='byond://?src=\ref[src];embedded_object=\ref[J];embedded_limb=\ref[L]'>Embedded in [L]: [J]</a><br></td></tr>"
+	
 	dat += {"</table>
 	<A href='?src=\ref[user];mach_close=mob\ref[src]'>Close</A>
 	"}
@@ -234,7 +237,6 @@
 
 	spreadFire(AM)
 
-
 /mob/living/carbon/human/Topic(href, href_list)
 	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 
@@ -244,8 +246,8 @@
 			if(!I || !L || I.loc != src || !(I in L.embedded_objects)) //no item, no limb, or item is not in limb or in the person anymore
 				return
 			var/time_taken = I.embedded_unsafe_removal_time*I.w_class
-			usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [usr == src ? "their" : name + "'s"] [L.name].</span>",\
-				                "<span class='notice'>You attempt to remove [I] from [usr == src ? "your" : name + "'s"] [L.name]... (It will take [time_taken/10] seconds.)</span>")
+			usr.visible_message("<span class='warning'>[usr] attempts to remove \the [I] from [usr == src ? "their" : name + "'s"] [L.name].</span>",\
+				                "<span class='notice'>You attempt to remove \the [I] from [usr == src ? "your" : name + "'s"] [L.name]... (It will take [time_taken/10] seconds.)</span>")
 			if(do_after(usr, time_taken, needhand = 1, target = src))
 				if(!I || !L || I.loc != src || !(I in L.embedded_objects))
 					return
@@ -255,8 +257,8 @@
 				usr.put_in_hands(I)
 				emote("scream")
 
-				visible_message("[usr] successfully rips [I] out of [usr == src ? "their" : name + "'s"] [L.name]!",\
-					            "<span class='notice'>You successfully remove [I] from [usr == src ? "your" : name + "'s"] [L.name].</span>")
+				visible_message("[usr] successfully rips \the [I] out of [usr == src ? "their" : name + "'s"] [L.name]!",\
+					            "<span class='notice'>You successfully remove \the [I] from [usr == src ? "your" : name + "'s"] [L.name].</span>")
 				if(!has_embedded_objects())
 					clear_alert("embeddedobject")
 			return

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -263,7 +263,9 @@
 		return
 	else
 		var/sound
-		if(!user.is_muzzled() && !user.mind.miming)
+		var/miming = user.mind ? user.mind.miming : 0
+
+		if(!user.is_muzzled() && !miming)
 			if(iscyborg(user))
 				var/mob/living/silicon/robot/S = user
 				if(S.cell.charge < 20)
@@ -299,7 +301,7 @@
 				user.adjustOxyLoss(5)
 			playsound(user.loc, sound, 50, 1, 4, 1.2)
 			message = "screams!"
-		else if(user.mind.miming)
+		else if(miming)
 			message = "acts out a scream."
 		else
 			message = "makes a very loud noise."


### PR DESCRIPTION
🆑 John Ginnane
fix: Fixed being unable to remove embedded objects without surgery
/🆑

The Topic() handled a case where someone hit the "embedded_object" link already so...

Also had to work on run_emote() to handle cases where a /living/ didn't have a mind (unlikely scenario)

Fixes #61 