### PR TITLE
Medical wrench and surplus limbs crate

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -35501,10 +35501,7 @@
 /area/medical/sleeper)
 "bzh" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/wrench{
-	pixel_x = 5;
-	pixel_y = -5
-	},
+/obj/item/weapon/wrench/medical,
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
@@ -38609,8 +38606,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bFF" = (
-/obj/machinery/limbgrower,
-/obj/item/weapon/reagent_containers/glass/beaker/synthflesh,
+/obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bFG" = (


### PR DESCRIPTION
:cl: Tortellini Tony
fix: The wrench in medical is now a proper medical wrench.
add: A box of surplus limbs has replaced the limb grower.
/:cl:

TG replaced the limb grower similarily, and this acts as a sort of nerf since we have limb flowers that produce real limbs. If you want a quick and cheap limb, you get a surplus one from this box.