### PR TITLE
Borrows /tg/s blob spore fix.

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -167,8 +167,9 @@
 	if(factory)
 		factory.spores -= src
 	factory = null
-	oldguy.forceMove(loc)
-	oldguy = null
+	if(oldguy)
+		oldguy.forceMove(get_turf(src))
+		oldguy = null
 	return ..()
 
 /mob/living/simple_animal/hostile/blob/blobspore/update_icons()


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/24377

Copies this fix over, doesn't mention the commits properly because I'm not very good at git.

Has all been tested locally and it works. 

credit goes to lzimann for fixing this shit.
:cl: Guyonbroadway
fix: Fixes blob spores spawning invincible yet inert fragile blob spores. Credit to lzimann from /tg/ for the fix.
/:cl:

