### PR TITLE
Adds revamped cryogenic fluid

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -42,7 +42,8 @@
 /obj/item/weapon/extinguisher/New()
 	..()
 	create_reagents(max_water)
-	reagents.add_reagent("water", max_water)
+	reagents.add_reagent("water", (max_water - 10))
+	reagents.add_reagent("cryogenic_fluid", 10) //improved turf extinguishing
 
 /obj/item/weapon/extinguisher/attack_self(mob/user)
 	safety = !safety

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -223,3 +223,58 @@
 		M.electrocute_act(rand(5,20), "Teslium in their body", 1, 1) //Override because it's caused from INSIDE of you
 		playsound(M, "sparks", 50, 1)
 	..()
+
+/datum/reagent/cryogenic_fluid
+	name = "Cryogenic Fluid"
+	id = "cryogenic_fluid"
+	description = "Extremely cold superfluid used to put out fires that will viciously freeze people on contact causing severe pain and burn damage, weak if ingested."
+	color = "#b3ffff"
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
+
+/datum/reagent/cryogenic_fluid/on_mob_life(mob/living/M) //not very pleasant but fights fires
+	M.adjust_fire_stacks(-2)
+	M.adjustStaminaLoss(2)
+	M.adjustBrainLoss(1)
+	M.bodytemperature = max(M.bodytemperature - 10, TCMB)
+	..()
+
+/datum/reagent/cryogenic_fluid/on_tick()
+	holder.chem_temp -= 5
+	..()
+
+/datum/reagent/cryogenic_fluid/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
+	if(iscarbon(M) && M.stat != DEAD)
+		if(method in list(INGEST,INJECT))
+			M.bodytemperature = max(M.bodytemperature - 50, TCMB)
+			if(show_message)
+				M << "<span class='warning'>You feel like you are freezing from the inside!</span>"
+		else
+			if (reac_volume >= 5)
+				if(show_message)
+					M << "<span class='danger'>You can feel your body freezing up and your metabolism slow, the pain is excruciating!</span>"
+				M.bodytemperature = max(M.bodytemperature - 5*reac_volume, TCMB) //cold
+				M.adjust_fire_stacks(-(12*reac_volume))
+				M.losebreath += (0.2*reac_volume) //no longer instadeath rape but losebreath instead much more immulshion friendly
+				M.drowsyness += 2
+				M.confused += 6
+				M.brainloss += (0.25*reac_volume) //hypothermia isn't good for the brain
+
+			else
+			 M.bodytemperature = max(M.bodytemperature - 15, TCMB)
+			 M.adjust_fire_stacks(-(6*reac_volume))
+	 ..()
+
+/datum/reagent/cryogenic_fluid/reaction_turf(turf/T, reac_volume)
+	if (!istype(T)) return
+	var/obj/effect/hotspot/hotspot = (locate(/obj/effect/hotspot) in T) //instantly delts hotspots
+	if(isopenturf(T))
+		var/turf/open/O = T
+		if(hotspot)
+			if(O.air)
+				var/datum/gas_mixture/G = O.air
+				G.temperature = 0
+				G.react()
+				qdel(hotspot)
+
+		if(reac_volume >= 6)
+			T.freon_gas_act() //freon in my pocket

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -346,7 +346,7 @@
 	required_reagents = list("stable_plasma" = 1, "radium" = 1, "phosphorus" = 1)
 
 /datum/chemical_reaction/pyrosium/on_reaction(datum/reagents/holder, created_volume)
-	holder.chem_temp = 20 // also cools the fuck down
+	holder.chem_temp += 500 // also heats the fuck up AGAIN
 	return
 
 /datum/chemical_reaction/teslium
@@ -397,3 +397,18 @@
 	strengthdiv = 7
 	required_temp = 575
 	modifier = 1
+
+/datum/chemical_reaction/cryogenic_fluid
+	name = "cryogenic_fluid"
+	id = "cryogenic_fluid"
+	results = list("cryogenic_fluid" = 4)
+	required_reagents = list("cryostylane" = 2, "lube" = 1, "pyrosium" = 2) //kinda difficult
+	required_catalysts = list("plasma" = 1)
+	required_temp = 100
+	is_cold_recipe = TRUE
+	mob_react = FALSE
+	mix_message = "<span class='danger'>In a sudden explosion of vapour, the container begins to rapidly freeze and a frothing fluid begins to creep up the edges!</span>"
+
+/datum/chemical_reaction/cryogenic_fluid/on_reaction(datum/reagents/holder, created_volume)
+	holder.chem_temp = 0 // cools the fuck down
+	return


### PR DESCRIPTION

:cl: banthebantz
add: Readded Cryogenic fluid as an even more effective fire fighting chemical. It reduces firestacks very effectively and instantly deletes hotspots, it is found in trace quantities in fire extinguishers. On contact and when ingested it causes scaling brain damage and cooling along with suffocation. When applied to a turf or object in sufficient quantities it will also act like freon creating a winter wonderland.
add: Cryogenic fluid is now made with 2 parts cryostylane, 1 part lube and 2 parts pyrosium in the presence of a plasma catalyst and when cooled to 100 kelvin or below
/:cl:

[]: # It was in for a while before but didn't see too much use other than as a lesser known murder chem. Now I've nerfed the murder and upped the firefighting and made it more interesting by acting as the game's only on touch brain damage chem and pocket freon. The recipe is also harder than it used to be.
