### PR TITLE
Fixed chameleon items allowing you to select items with no icon_state

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -84,7 +84,7 @@
 	for(var/V in typesof(chameleon_type))
 		if(ispath(V, /obj/item))
 			var/obj/item/I = V
-			if(chameleon_blacklist[V] || (initial(I.flags) & ABSTRACT))
+			if(chameleon_blacklist[V] || (initial(I.flags) & ABSTRACT) || !I.icon_state)
 				continue
 			chameleon_list += I
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -2,6 +2,7 @@
 	name = "glasses"
 	materials = list(MAT_GLASS = 250)
 	var/glass_colour_type = null //colors your vision when worn
+	icon_state = "glasses"
 
 /obj/item/clothing/glasses/visor_toggling()
 	..()


### PR DESCRIPTION
🆑 John Ginnane
fix: Fixed chameleon thermals allowing you to select items with no icon_state, so no more invisible items! This also means "glasses" now show up properly
/🆑

The base item, which is included in the chameleon list, didn't have an
icon_state set. I've set it to the normal "glasses" one, and added a
check to the chameleon verb so any other items that are missing an
icon_state won't appear in the list

Fixes #113 