### PR TITLE
Fixes symbols in nearcrit whispers

### DIFF
--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -12,7 +12,7 @@
 		return
 
 
-	message = trim(html_encode(message))
+	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 	if(!can_speak(message))
 		return
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -61,6 +61,12 @@ var/list/department_radio_keys = list(
 var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 
 /mob/living/say(message, bubble_type,var/list/spans = list(), sanitize = TRUE)
+
+	if(is_nearcrit(src) && !stat)
+		whisper(message)
+		adjustOxyLoss(1)
+		return
+
 	if(sanitize)
 		message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 	if(!message || message == "")
@@ -82,11 +88,6 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 
 	var/message_mode = get_message_mode(message)
 
-	if(is_nearcrit(src) && !stat)
-		whisper(message)
-		adjustOxyLoss(1)
-		return
-	
 	if(stat && !(message_mode in crit_allowed_modes))
 		return
 


### PR DESCRIPTION
:cl: cacogen
fix: Symbols now display properly when using say in nearcrit.
/:cl:

Fixes #410 