### PR TITLE
Makes some buffs to clockwork cult to facilitate earlygame being less terrible.

### DIFF
--- a/code/__DEFINES/clockcult.dm
+++ b/code/__DEFINES/clockcult.dm
@@ -36,13 +36,13 @@ var/global/list/all_scripture = list() //a list containing scripture instances; 
 #define JUDGEMENT_CV_REQ 300
 
 //general component/cooldown things
-#define SLAB_PRODUCTION_TIME 900 //how long(deciseconds) slabs require to produce a single component; defaults to 1 minute 30 seconds
+#define SLAB_PRODUCTION_TIME 600 //how long(deciseconds) slabs require to produce a single component; defaults to 1 minute
 
 #define SLAB_SERVANT_SLOWDOWN 300 //how much each servant above 5 slows down slab-based generation; defaults to 30 seconds per sevant
 
 #define SLAB_SLOWDOWN_MAXIMUM 2700 //maximum slowdown from additional servants; defaults to 4 minutes 30 seconds
 
-#define CACHE_PRODUCTION_TIME 900 //how long(deciseconds) caches require to produce a component; defaults to 1 minute 30 seconds
+#define CACHE_PRODUCTION_TIME 400 //how long(deciseconds) caches require to produce a component; defaults to 40 seconds
 
 #define LOWER_PROB_PER_COMPONENT 10 //how much each component in the cache reduces the weight of getting another of that component type
 

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_proselytizer.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_proselytizer.dm
@@ -14,7 +14,7 @@
 	var/repairing = null //what we're currently repairing, if anything
 	var/speed_multiplier = 1 //how fast this proselytizer works
 	var/charge_rate = MIN_CLOCKCULT_POWER //how much power we gain every two seconds
-	var/charge_delay = 2 //how many proccess ticks remain before we can start to charge
+	var/charge_delay = 1 //how many proccess ticks remain before we can start to charge
 
 /obj/item/clockwork/clockwork_proselytizer/preloaded
 	stored_power = POWER_WALL_MINUS_FLOOR+POWER_WALL_TOTAL
@@ -26,7 +26,7 @@
 	item_state = "nothing"
 	w_class = WEIGHT_CLASS_TINY
 	speed_multiplier = 0.5
-	charge_rate = MIN_CLOCKCULT_POWER * 2
+	charge_rate = MIN_CLOCKCULT_POWER * 4
 	var/debug = FALSE
 
 /obj/item/clockwork/clockwork_proselytizer/scarab/proselytize(atom/target, mob/living/user)

--- a/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
@@ -10,7 +10,7 @@
 	var/active = FALSE //If the visor is online
 	var/recharging = FALSE //If the visor is currently recharging
 	var/obj/effect/proc_holder/judicial_visor/blaster
-	var/recharge_cooldown = 300 //divided by 10 if ratvar is alive
+	var/recharge_cooldown = 100 //divided by 5 if ratvar is alive
 	actions_types = list(/datum/action/item_action/clock/toggle_visor)
 
 /obj/item/clothing/glasses/judicial_visor/New()
@@ -131,7 +131,7 @@
 				continue
 			V.recharging = TRUE //To prevent exploiting multiple visors to bypass the cooldown
 			V.update_status()
-			addtimer(CALLBACK(V, /obj/item/clothing/glasses/judicial_visor.proc/recharge_visor, ranged_ability_user), (ratvar_awakens ? visor.recharge_cooldown*0.1 : visor.recharge_cooldown) * 2)
+			addtimer(CALLBACK(V, /obj/item/clothing/glasses/judicial_visor.proc/recharge_visor, ranged_ability_user), (ratvar_awakens ? visor.recharge_cooldown*0.2 : visor.recharge_cooldown) * 2)
 		clockwork_say(ranged_ability_user, text2ratvar("Kneel, heathens!"))
 		ranged_ability_user.visible_message("<span class='warning'>[ranged_ability_user]'s judicial visor fires a stream of energy at [target], creating a strange mark!</span>", "<span class='heavy_brass'>You direct [visor]'s power to [target]. You must wait for some time before doing this again.</span>")
 		var/turf/targetturf = get_turf(target)

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
@@ -262,7 +262,7 @@
 /datum/clockwork_scripture/create_object/tinkerers_daemon
 	descname = "Powered Structure, Component Generator"
 	name = "Tinkerer's Daemon"
-	desc = "Creates a tinkerer's daemon which can rapidly collect components. It will only function if it has sufficient power, is outnumbered by Servants by a ratio of 5:1, \
+	desc = "Creates a tinkerer's daemon which can rapidly collect components. It will only function if it has sufficient power, is outnumbered by Servants by a ratio of 4:1, \
 	and there is at least one existing cache."
 	invocations = list("May this generator...", "...collect Engine parts that yet hold greatness!")
 	channel_time = 80

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
@@ -284,10 +284,10 @@
 	for(var/mob/living/L in living_mob_list)
 		if(is_servant_of_ratvar(L))
 			servants++
-	if(servants * 0.2 < clockwork_daemons)
+	if(servants * 0.25 < clockwork_daemons)
 		invoker << "<span class='nezbere'>\"Daemons are already disabled, making more of them would be a waste.\"</span>"
 		return FALSE
-	if(servants * 0.2 < clockwork_daemons+1)
+	if(servants * 0.25 < clockwork_daemons+1)
 		invoker << "<span class='nezbere'>\"This daemon would be useless, friend.\"</span>"
 		return FALSE
 	return ..()

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_drivers.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_drivers.dm
@@ -112,7 +112,7 @@
 	desc = "Charges your slab with divine energy, allowing you to bind a nearby heretic for conversion. This is very obvious and will make your slab visible in-hand."
 	invocations = list("Divinity, grant...", "...me strength...", "...to enlighten...", "...the heathen!")
 	whispered = TRUE
-	channel_time = 20
+	channel_time = 10
 	usage_tip = "Is melee range and does not penetrate mindshield implants. Much more efficient than a Sigil of Submission at low Servant amounts."
 	tier = SCRIPTURE_DRIVER
 	primary_component = GEIS_CAPACITOR
@@ -135,14 +135,14 @@
 	if(servants > SCRIPT_SERVANT_REQ)
 		whispered = FALSE
 		servants -= SCRIPT_SERVANT_REQ
-		channel_time = min(channel_time + servants*3, 50)
+		channel_time = min(channel_time + servants*2, 50)
 	return ..()
 
 //The scripture that does the converting.
 /datum/clockwork_scripture/geis
 	name = "Geis Conversion"
 	invocations = list("Enlighten this heathen!", "All are insects before Engine!", "Purge all untruths and honor Engine.")
-	channel_time = 49
+	channel_time = 25
 	tier = SCRIPTURE_PERIPHERAL
 	var/mob/living/target
 	var/obj/structure/destructible/clockwork/geis_binding/binding

--- a/code/game/gamemodes/clock_cult/clock_structures/tinkerers_daemon.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/tinkerers_daemon.dm
@@ -2,7 +2,7 @@
 /obj/structure/destructible/clockwork/powered/tinkerers_daemon
 	name = "tinkerer's daemon"
 	desc = "A strange machine with three small brass obelisks attached to it."
-	clockwork_desc = "An efficient machine that can rapidly produce components at a small power cost. It will only function if outnumbered by servants at a rate to 5:1."
+	clockwork_desc = "An efficient machine that can rapidly produce components at a small power cost. It will only function if outnumbered by servants at a rate to 4:1."
 	icon_state = "tinkerers_daemon"
 	active_icon = "tinkerers_daemon"
 	inactive_icon = "tinkerers_daemon"
@@ -18,7 +18,7 @@
 	var/image/component_glow
 	var/component_id_to_produce
 	var/production_time = 0 //last time we produced a component
-	var/production_cooldown = 120
+	var/production_cooldown = 90
 
 /obj/structure/destructible/clockwork/powered/tinkerers_daemon/New()
 	..()
@@ -43,7 +43,7 @@
 /obj/structure/destructible/clockwork/powered/tinkerers_daemon/forced_disable(bad_effects)
 	if(active)
 		if(bad_effects)
-			try_use_power(MIN_CLOCKCULT_POWER*4)
+			try_use_power(MIN_CLOCKCULT_POWER*2)
 			visible_message("<span class='warning'>[src] shuts down with a horrible grinding noise!</span>")
 			playsound(src, 'sound/magic/clockwork/anima_fragment_attack.ogg', 50, 1)
 		else
@@ -65,7 +65,7 @@
 		for(var/mob/living/L in living_mob_list)
 			if(is_servant_of_ratvar(L))
 				servants++
-		if(servants * 0.2 < clockwork_daemons)
+		if(servants * 0.25 < clockwork_daemons)
 			user << "<span class='nezbere'>\"There are too few servants for this daemon to work.\"</span>"
 			return
 		if(!clockwork_caches)


### PR DESCRIPTION
Clock cult has some real problems getting started, partly due to lack of information but their start being slow as fuck does not help. this speeds things up so they can get their components, conversion and construction going much faster and allows then to use more toys due to having a better economy. 

:cl: Guyonbroadway
tweak: The Judicial Visor's Cooldown has been reduced to 10 seconds, and down to 2 when Ratvar is alive. (Was 30 and 3 respectivly)
tweak: Clockwork slabs and caches now produce components much faster so you can freely spend them on more fun things like guardians and judicial visors. 
tweak: the clockwork proselytizer (seriously, who the fuck came up with that name?) now charges twice as fast.
tweak: The geis conversion spell now converts converts much faster, to the point where early game it's near impossible for a new convert to break out of the ring on their own. Later game it is possible to resist out.
/:cl:

